### PR TITLE
test(REQ-INF-001): finalize visibility of 'ci / verify' status check in branch protection

### DIFF
--- a/.force-verify.md
+++ b/.force-verify.md
@@ -1,0 +1,1 @@
+# force verify registration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   verify:
+    name: verify
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.verify-trigger.md
+++ b/.verify-trigger.md
@@ -1,0 +1,1 @@
+# trigger verify registration in public repo


### PR DESCRIPTION
This pull request ensures that the `ci / verify` job is explicitly named and re-triggered in a public PR targeting `main`.

- References: REQ-INF-001 / SPEC-INF-002
- Adds `name: verify` to the CI job for consistent check registration
- Triggers one final CI run to surface the job in GitHub’s branch protection UI

Once CI passes, the job `ci / verify` should appear in the list of required status checks for the `main` branch and can be enforced.
