### PR TITLE
docs(REQ-INF-001): update CHANGELOG.md for v1.0.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # 📦 Changelog
 
+## v1.0.1 — GitHub Protections & Infrastructure Traceability
+
+🔹 **Release Date:** 2025-05-16  
+🔹 **Commit:** `0666a01`  
+🔹 **Summary:** Hardened the repository with GitHub branch protections and made infrastructure requirements fully traceable.
+
+### 🔧 Improvements
+
+- ✅ Enforced **GitHub-side protections**:
+  - Locked `main` branch (no direct pushes)
+  - Required pull requests for all merges
+  - Required status check: `CI / verify`
+
+- ✅ CI validation fixes:
+  - Commit message validation improved for pull requests
+  - Resolved commit message parsing via `GITHUB_ENV`
+  - Added test triggers to register GitHub status check `verify`
+
+- ✅ New infrastructure REQs:
+  - `REQ-INF-001`: CI runs on pull_request targeting main
+  - `REQ-INF-002`: Commit messages must reference a valid REQ
+  - `REQ-INF-003`: All CI steps must validate traceability
+
+- 📋 Updated:
+  - `requirements.md` with `REQ-INF-XXX` entries
+  - `TRACEABILITY.md` to include CI/tooling REQs
+  - `README.md` to reflect enforcement guarantees
+
+---
+
 ## v1.0.0 — Initial Release
 
 🔹 **Release Date:** 2025-05-13  
@@ -26,4 +56,4 @@
 
 ---
 
-🔁 This version is CI-locked, fully auditable, and suitable for safety-critical traceability workflows.
+🔁 All releases are CI-locked, traceable, and auditable for safety-critical development.


### PR DESCRIPTION
This PR updates the CHANGELOG.md file to accurately reflect the contents of release v1.0.1:

- GitHub-side branch protections enforced
- CI validation of commit messages and REQ links
- REQ-INF-001, REQ-INF-002, REQ-INF-003 registered and enforced
- Summary of traceability enforcement logic

This commit corrects an earlier changelog inconsistency and aligns mainline documentation with the tagged state of v1.0.1.
