### PR TITLE
docs(REQ-INF-011): allow documentation of REQs before implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ This repository demonstrates **end-to-end traceability enforcement**. The design
 5. **Traceability Matrix** → Auto-generated via `GENERATE_TRACEABILITY_MATRIX.py`
 6. **CI Enforcement** → Rejects any commit or PR that violates traceability rules
 
-## 🧪 CI Enforced Rules
+🧪 CI Enforced Rules
 
-- All requirements must be implemented and tested
-- No implementation or test without a declared requirement
-- Commit messages must reference at least one REQ-ID
-- All functions and test cases must be annotated with REQ-ID
-- Traceability matrix must be valid and complete
+-  All implemented requirements must be tested.
+-  Unimplemented REQs may exist (planned documentation is allowed).
+-  No implementation or test without a declared requirement.
+-  Commit messages must reference at least one REQ-ID.
+-  All functions and test cases must be annotated with REQ-ID.
+-  Traceability matrix must be valid and complete.
+
 
 ## 💻 Usage
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -32,3 +32,4 @@ This specification applies to the development environment that enforces requirem
 | SPEC-INF-008   | CI shall generate detailed coverage and requirement validation artifacts.   |
 | SPEC-INF-009   | Commit messages and PR titles shall follow the REQ-ID enforcement pattern.  |
 | SPEC-INF-010   | All traceability-relevant scripts must include logging for transparency.    |
+| SPEC-INF-011  | CI shall allow unimplemented REQs but block implemented REQs without tests.  |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -24,3 +24,4 @@
 | REQ-INF-008  | CI must export traceability and test artifacts.                             | SPEC-INF-008     |
 | REQ-INF-009  | CI must validate commit messages and PR titles contain valid REQ-IDs.       | SPEC-INF-009     |
 | REQ-INF-010  | All enforcement scripts must include logging for auditability.              | SPEC-INF-010     |
+| REQ-INF-011  | The system shall allow REQs to be declared before implementation, but block untested implementations. | SPEC-INF-011 |


### PR DESCRIPTION
allow documentation of REQs before implementation in order to define requirements in advance. The CI will not fail for not implemented requirements, but for implemented ones which are not being tested